### PR TITLE
Return an error when enddate is before startdate

### DIFF
--- a/www/events.php
+++ b/www/events.php
@@ -33,20 +33,31 @@ if (isset($_GET['enddate']) && ($parseddate = strtotime($_GET['enddate']))) {
     $enddate = time();
 }
 
-$json = array('events' => array());
+$json = array();
 
-if (isset($_GET['id'])) {
-    $events = EventTime::getByID($_GET['id']);
-}
-else {
-    $events = EventTime::getRangeVisible($startdate, $enddate);
-}
-foreach ($events as $eventTime) {
-    try{
-        $json['events'] []= $eventTime->toEventSummaryArray();
-    } catch( Exception $ex ) {
-        // For now, ignore
+if ($enddate < $startdate) {
+    http_response_code(400);
+    $message = "enddate: " . date('Y-m-d', $enddate) . " is before startdate: " . date('Y-m-d', $startdate);
+    $json['error'] = array(
+        'message' => $message
+    );
+} else {
+    $json['events'] = array();
+
+    if (isset($_GET['id'])) {
+        $events = EventTime::getByID($_GET['id']);
+    }
+    else {
+        $events = EventTime::getRangeVisible($startdate, $enddate);
     }
 
+    foreach ($events as $eventTime) {
+        try{
+            $json['events'] []= $eventTime->toEventSummaryArray();
+        } catch( Exception $ex ) {
+            // For now, ignore
+        }
+
+    }
 }
 fJSON::output($json);


### PR DESCRIPTION
When making a request to `events.php`, `startdate` and/or `enddate` will default to today if not specified. If today is June 1 and you make the seemingly valid request of `/events.php?startdate=2018-06-02`, previously it would simply return an empty events list since the `enddate` was before `startdate`. (This would also occur if you explicitly provided the `enddate` param with the same dates, `/events.php?startdate=2018-06-02&enddate=2018-06-01`.)

The events API now checks for useless combos like that. It will return a 400 error and a message which includes the start and end dates requested (which helps to clarify why the error is occurring, if one of them was a default). This could have helped identify a previous "load more events" bug by reporting explicitly that the start and end dates had been swapped.

Note that it is still valid to make a request where `startdate` and `enddate` are the same, e.g. `/events.php?startdate=2018-06-01&enddate=2018-06-01`.

We could also look into using different default values rather than simply using the current time, so that default values can't produce error states. Even so, this change would still be useful for explicitly provided params which are not valid.