### PR TITLE
Add id, status, and newsflash persistence to datepicker + make a few styling changes

### DIFF
--- a/www/css/main.css
+++ b/www/css/main.css
@@ -421,9 +421,14 @@ form#event-entry .date-select-container-style {
     float: right;
     clear: right;
 }
+#date-selected-container {
+    padding: 0 4px;
+    font-weight: bold;
+}
 #date-selected {
     list-style-type: none;
-    padding: 0 4px;
+    padding: 0;
+    font-weight: normal;
 }
 button.jump-to-date {
     float: right;

--- a/www/css/main.css
+++ b/www/css/main.css
@@ -246,6 +246,13 @@ h1 {
     border-radius: 2px;
     padding: 2px 4px;
     overflow-wrap: break-word;
+    width: 100%;
+    margin-bottom: 4px;
+    text-align: center;
+}
+
+.status-selector {
+    float: right;
 }
 
 .col-xs-2 {
@@ -416,7 +423,7 @@ form#event-entry .date-select-container-style {
 }
 #date-selected {
     list-style-type: none;
-    padding: 0;
+    padding: 0 4px;
 }
 button.jump-to-date {
     float: right;

--- a/www/index.html
+++ b/www/index.html
@@ -636,8 +636,10 @@
                                     </table>
                                     <div id="load-later" class="loading-zone"></div>
                                 </div>
-                                Selected dates:
-                                <ul id="date-selected"></ul>
+                                <div id="date-selected-container">
+                                    Selected dates:
+                                    <ul id="date-selected"></ul>
+                                </div>
                             </div>
                             </div>
 

--- a/www/js/addevent.js
+++ b/www/js/addevent.js
@@ -13,7 +13,7 @@
                 populateEditForm( data, callback );
             });
         } else {
-            populateEditForm({ dates: [] }, callback);
+            populateEditForm({ datestatuses: [] }, callback);
         }
     };
 
@@ -103,7 +103,7 @@
                 top: 100
             }
         });
-        if (shiftEvent.datestatuses.length === 0) {
+        if (shiftEvent['datestatuses'].length === 0) {
             $('#save-button').prop('disabled', true);
             $('#preview-button').prop('disabled', true);
         }

--- a/www/js/datepicker.js
+++ b/www/js/datepicker.js
@@ -52,10 +52,13 @@
         // Fill in global variables
         // Set up dateMap
         dateMap = {};
-        for (var i=0; i<dateStatuses.length; i++) {
-            dateMap[normalizeDate(dateStatuses[i]['date'])] = true;
+        dateStatuses.forEach(function(dateStatus) {
+            dateMap[normalizeDate(dateStatus['date'])] = {
+                selected: true,
+                dateStatus: dateStatus
+            }
             selectedCount++;
-        }
+        });
 
         // Scrolling container for the table
         $dateSelect = $('#date-select');
@@ -83,32 +86,44 @@
         $datePicker.click(function(ev) {
             var e = ev.target;
             if (e.hasAttribute('data-date')) {
-                var $e = $(e),
-                    date = $e.attr('data-date');
+                var $e = $(e);
+                var date = $e.attr('data-date');
 
-                dateMap[date] = !dateMap[date];
-                if (dateMap[date]) {
+                if (date in dateMap) {
+                    dateMap[date]['selected'] = !dateMap[date]['selected'];
+                    if (dateMap[date]['selected']) {
+                        selectedCount++;
+                        dateStatuses.push(dateMap[date]['dateStatus']);
+                        $('#save-button').prop('disabled', false);
+                        $('#preview-button').prop('disabled', false);
+                    } else {
+                        selectedCount--;
+                        var match = dateStatuses.findIndex(function(deselectedDate) {
+                            return deselectedDate['date'] == date;
+                        });
+                        dateStatuses.splice(match, 1);
+                        if ( selectedCount === 0 ) {
+                            $('#save-button').prop('disabled', true);
+                            $('#preview-button').prop('disabled', true);
+                        }
+                    }
+                } else {
+                    var newDateStatus = {
+                        id: null,
+                        date: date,
+                        status: 'A',
+                        newsflash: null
+                    };
+                    dateStatuses.push(newDateStatus);
+                    dateMap[date] = {
+                        selected: true,
+                        dateStatus: newDateStatus
+                    };
                     selectedCount++;
-                    dateStatuses.push({
-                        "id": null,
-                        "date": date,
-                        "status": 'A',
-                        "newsflash": null
-                    });
                     $('#save-button').prop('disabled', false);
                     $('#preview-button').prop('disabled', false);
-                } else {
-                    selectedCount--;
-                    var match = dateStatuses.findIndex(function(deselectedDate) {
-                      return deselectedDate['date'] == date;
-                    });
-                    dateStatuses.splice(match, 1);
-                    if ( selectedCount === 0 ) {
-                        $('#save-button').prop('disabled', true);
-                        $('#preview-button').prop('disabled', true);
-                    }
                 }
-                $e.toggleClass('selected', dateMap[date]);
+                $e.toggleClass('selected', dateMap[date]['selected']);
                 // TODO: make it so changing data selection on an existing event
                 // doesn't replace the list
                 $dateSelected.html("");

--- a/www/js/datepicker.js
+++ b/www/js/datepicker.js
@@ -112,7 +112,7 @@
                         id: null,
                         date: date,
                         status: 'A',
-                        newsflash: null 
+                        newsflash: null
                     };
                     dateStatuses.push(newDateStatus);
                     dateMap[date] = {
@@ -141,39 +141,33 @@
     };
 
     function buildSortedDatesListHTML(list, dateStatuses) {
-        dateStatuses
-            .sort(function(a, b){
-                // Sort dateStatuses in ascending order for display
-                return new Date(a['date']) - new Date(b['date']);
-            })
-            .forEach(function (dateStatus) {
-                var dateStatusId = dateStatus['id'] ? dateStatus['id'] : "";
-                var dateStatusNewsFlash = dateStatus['newsflash'] ? dateStatus['newsflash'] : "";
-                var cancelledSelected = dateStatus['status'] === 'C' ? "selected='selected'" : "";
-                var scheduledSelected =  dateStatus['status'] === 'A' ? "selected='selected'" : "";
+        dateStatuses.sort(function(a, b){
+            // Sort dateStatuses in ascending order for display
+            return new Date(a['date']) - new Date(b['date']);
+        }).forEach(function(dateStatus) {
+            // Display null values as empty strings
+            var dateStatusId = dateStatus['id'] ? dateStatus['id'] : "";
+            var dateStatusNewsFlash = dateStatus['newsflash'] ? dateStatus['newsflash'] : "";
+            var cancelledSelected = dateStatus['status'] === 'C' ? "selected='selected'" : "";
+            var scheduledSelected =  dateStatus['status'] === 'A' ? "selected='selected'" : "";
 
-                // Append selected date
-                list.append(
-                    "<li data-id='" + dateStatusId + 
-                    "'><span>" + dateStatus['date'] + "</span></li>"
-                );
-
-                // Append status selector
-                $("li:last").append("<select></select>");
-                $("li:last select").append(
-                    "<option value='A' " + 
-                    scheduledSelected +
-                    ">Scheduled</option><option value='C' " + 
-                    cancelledSelected +
-                    ">Cancelled</option></select>"
-                );
-
-                // Append newsflash
-                $("li:last").append(
-                    "<input type='text' class='newsflash' value='" + 
-                    dateStatusNewsFlash + "'>"
-                );
-            });
+            // Append selected date
+            list.append([
+                "<li data-id='" + dateStatusId + "'>",
+                    "<span >" + dateStatus['date'] + "</span>",
+                    "<select class='status-selector'>",
+                        "<option value='A' " + scheduledSelected + ">Scheduled</option>",
+                        "<option value='C' " + cancelledSelected + ">Cancelled</option>",
+                    "</select>",
+                    "<input ",
+                        "type='text' ",
+                        "placeholder='Cancellation News Flash' ",
+                        "class='newsflash' ",
+                        "value='" + dateStatusNewsFlash,
+                    "'>",
+                "</li>",
+            ].join(""));
+        });
     }
 
     function isToday(date) {

--- a/www/js/datepicker.js
+++ b/www/js/datepicker.js
@@ -112,7 +112,7 @@
                         id: null,
                         date: date,
                         status: 'A',
-                        newsflash: null
+                        newsflash: null 
                     };
                     dateStatuses.push(newDateStatus);
                     dateMap[date] = {
@@ -127,8 +127,7 @@
                 // TODO: make it so changing data selection on an existing event
                 // doesn't replace the list
                 $dateSelected.html("");
-                //selectedDatesListHTML($dateSelected, $datePicker.dateList());
-                savedDatesListHTML($dateSelected, dateStatuses);
+                buildSortedDatesListHTML($dateSelected, dateStatuses);
 
                 return false;
             }
@@ -137,39 +136,44 @@
 
         // Setup the month table scroll checks
         $dateSelect.scroll(checkBounds);
-        savedDatesListHTML($dateSelected, dateStatuses);
+        buildSortedDatesListHTML($dateSelected, dateStatuses);
         checkBounds();
     };
 
-    function selectedDatesListHTML(list, dates) {
-        $.each(dates, function( index ) {
-          list.append("<li>" + dates[index] + "</li>");
-        });
-        return list;
-    }
+    function buildSortedDatesListHTML(list, dateStatuses) {
+        dateStatuses
+            .sort(function(a, b){
+                // Sort dateStatuses in ascending order for display
+                return new Date(a['date']) - new Date(b['date']);
+            })
+            .forEach(function (dateStatus) {
+                var dateStatusId = dateStatus['id'] ? dateStatus['id'] : "";
+                var dateStatusNewsFlash = dateStatus['newsflash'] ? dateStatus['newsflash'] : "";
+                var cancelledSelected = dateStatus['status'] === 'C' ? "selected='selected'" : "";
+                var scheduledSelected =  dateStatus['status'] === 'A' ? "selected='selected'" : "";
 
-    function savedDatesListHTML(list, dateStatuses) {
-        $.each(dateStatuses, function( index ) {
-          if ( dateStatuses[index]['id'] ) {
-            list.append("<li data-id='" + dateStatuses[index]['id'] + "'><span>" + dateStatuses[index]['date'] + "</span></li>" );
-          } else {
-            list.append("<li data-id=''><span>" + dateStatuses[index]['date'] + "</span></li>" );
-          }
+                // Append selected date
+                list.append(
+                    "<li data-id='" + dateStatusId + 
+                    "'><span>" + dateStatus['date'] + "</span></li>"
+                );
 
-          $( "li:last" ).append("<select></select>");
-          if (dateStatuses[index]['status'] == 'C') {
-            $( "li:last select" ).append("<option value='A'>Scheduled</option><option value='C' selected='selected'>Cancelled</option></select>");
-          } else {
-            $( "li:last select" ).append("<option value='A' selected='selected'>Scheduled</option><option value='C'>Cancelled</option></select>");
-          }
+                // Append status selector
+                $("li:last").append("<select></select>");
+                $("li:last select").append(
+                    "<option value='A' " + 
+                    scheduledSelected +
+                    ">Scheduled</option><option value='C' " + 
+                    cancelledSelected +
+                    ">Cancelled</option></select>"
+                );
 
-          if ( dateStatuses[index]['newsflash']) {
-            $( "li:last" ).append("<input type='text' class='newsflash' value='" + dateStatuses[index]['newsflash'] + "'>");
-          } else {
-            $( "li:last" ).append("<input type='text' class='newsflash'>");
-          }
-        });
-        return list;
+                // Append newsflash
+                $("li:last").append(
+                    "<input type='text' class='newsflash' value='" + 
+                    dateStatusNewsFlash + "'>"
+                );
+            });
     }
 
     function isToday(date) {


### PR DESCRIPTION
It's not the prettiest but now metadata about each date persists through selection/deselection. If you have come up with a better way at this point feel free to ignore this PR. Basically what it does is:

1. Push existing date statuses into dateMap as an object holding the boolean 'selected' value and the existing date status.
2. On click, check if there is an entry in the dateMap for the selected date.
3. If so, the logic proceeds as usual, but if the date has been selected, we push the contents of the existing 'dateStatus' field instead of creating a new dateStatus.
4. If no entry exists, push a new dateStatus.